### PR TITLE
Add __repr__ methods to DIDL classes for easier debugging

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -6,6 +6,7 @@ Changes
 - `DidlObject.resources` is now deprecated, use `DidlObject.res` instead
 - Rename `utils.ns_tag` to `utils.expand_namespace_tag`
 - Rename `utils.namespace_tag` to `utils.split_namespace_tag`
+- Add `__repr__` methods to DIDL classes for easier debugging
 
 
 1.2.6 (2021-03-04)

--- a/didl_lite/didl_lite.py
+++ b/didl_lite/didl_lite.py
@@ -2,7 +2,7 @@
 """DIDL-Lite (Digital Item Declaration Language) tools for Python."""
 # pylint: disable=too-many-lines
 
-from typing import Any, Dict, List, Optional, Sequence, Type, TypeVar, Union
+from typing import Any, Dict, Iterable, List, Optional, Sequence, Type, TypeVar, Union
 from xml.etree import ElementTree as ET
 
 import defusedxml.ElementTree
@@ -550,6 +550,21 @@ class Container(DidlObject, list):
         ("didl_lite", "@searchable", "O"),
         ("didl_lite", "@neverPlayable", "O"),
     ]
+
+    def __init__(
+        self,
+        id: str = "",
+        parent_id: str = "",
+        descriptors: Optional[Sequence["Descriptor"]] = None,
+        xml_el: Optional[ET.Element] = None,
+        strict: bool = True,
+        children: Iterable[DidlObject] = (),
+        **properties: Any,
+    ) -> None:
+        """Initialize."""
+        # pylint: disable=redefined-builtin,too-many-arguments
+        super().__init__(id, parent_id, descriptors, xml_el, strict, **properties)
+        self.extend(children)
 
     @classmethod
     def from_xml(cls: Type[TC], xml_el: ET.Element, strict: bool = True) -> TC:

--- a/didl_lite/didl_lite.py
+++ b/didl_lite/didl_lite.py
@@ -187,6 +187,16 @@ class DidlObject:
             raise AttributeError(name)
         return self.__dict__[name]
 
+    def __repr__(self) -> str:
+        """Evaluatable string representation of this object."""
+        class_name = type(self).__name__
+        attr = ", ".join(
+            f"{key}={val!r}"
+            for key, val in self.__dict__.items()
+            if key not in ("class", "xml_el")
+        )
+        return f"{class_name}({attr})"
+
 
 # region: items
 class Item(DidlObject):
@@ -566,6 +576,17 @@ class Container(DidlObject, list):
 
         return container_el
 
+    def __repr__(self) -> str:
+        """Evaluatable string representation of this object."""
+        class_name = type(self).__name__
+        attr = ", ".join(
+            f"{key}={val!r}"
+            for key, val in self.__dict__.items()
+            if key not in ("class", "xml_el")
+        )
+        children_repr = ", ".join(repr(child) for child in self)
+        return f"{class_name}({attr}, children=[{children_repr}])"
+
 
 class Person(Container):
     """DIDL Person."""
@@ -883,6 +904,16 @@ class Resource:
         res_el.text = self.uri
         return res_el
 
+    def __repr__(self) -> str:
+        """Evaluatable string representation of this object."""
+        class_name = type(self).__name__
+        attr = ", ".join(
+            f"{key}={val!r}"
+            for key, val in self.__dict__.items()
+            if val is not None and key != "xml_el"
+        )
+        return f"{class_name}({attr})"
+
 
 class Descriptor:
     """DIDL Descriptor."""
@@ -929,6 +960,16 @@ class Descriptor:
         if name not in self.__dict__:
             raise AttributeError(name)
         return self.__dict__[name]
+
+    def __repr__(self) -> str:
+        """Evaluatable string representation of this object."""
+        class_name = type(self).__name__
+        attr = ", ".join(
+            f"{key}={val!r}"
+            for key, val in self.__dict__.items()
+            if val is not None and key != "xml_el"
+        )
+        return f"{class_name}({attr})"
 
 
 # endregion

--- a/tests/test_didl_lite.py
+++ b/tests/test_didl_lite.py
@@ -130,6 +130,27 @@ class TestDidlLite:
         assert res_el.attrib["protocolInfo"] == "protocol_info"
         assert res_el.text == "url"
 
+    def test_item_repr(self) -> None:
+        """Test item's repr can convert back to an equivalent item."""
+        # repr method doens't know how package was imported, so only uses class names
+        from didl_lite.didl_lite import AudioItem, Resource
+
+        item = AudioItem(
+            id="0",
+            parent_id="0",
+            title="Audio Item Title",
+            restricted="1",
+            res=[
+                Resource("url", "protocol_info"),
+                Resource("url2", "protocol_info2"),
+            ],
+            language="English",
+        )
+
+        item_repr = repr(item)
+        item_remade = eval(item_repr)
+        assert ET.tostring(item.to_xml()) == ET.tostring(item_remade.to_xml())
+
     def test_container_from_xml(self) -> None:
         """Test container from XML."""
         didl_string = """
@@ -219,6 +240,28 @@ class TestDidlLite:
         assert res_el is not None
         assert res_el.attrib["protocolInfo"] == "protocol_info"
         assert res_el.text == "url"
+
+    def test_container_repr(self) -> None:
+        """Test containers's repr can convert back to an equivalent container."""
+        from didl_lite.didl_lite import Album, AudioItem, Resource
+
+        container = Album(
+            id="0", parent_id="0", title="Audio Item Title", restricted="1"
+        )
+        resource = Resource("url", "protocol_info")
+        item = AudioItem(
+            id="0",
+            parent_id="0",
+            title="Audio Item Title",
+            restricted="1",
+            resources=[resource],
+            language="English",
+        )
+        container.append(item)
+
+        container_repr = repr(container)
+        container_remade = eval(container_repr)
+        assert ET.tostring(container.to_xml()) == ET.tostring(container_remade.to_xml())
 
     def test_descriptor_from_xml_root(self) -> None:
         """Test root descriptor from XML."""
@@ -375,6 +418,18 @@ class TestDidlLite:
         assert len(descriptor_el.attrib) == 2
         assert descriptor_el.attrib["id"] == "2"
         assert descriptor_el.attrib["nameSpace"] == "ns2"
+
+    def test_descriptor_repr(self) -> None:
+        """Test descriptor's repr can convert back to an equivalent descriptorb."""
+        from didl_lite.didl_lite import Descriptor
+
+        descriptor = Descriptor(id="1", name_space="ns", type="type", text="Text")
+
+        descriptor_repr = repr(descriptor)
+        descriptor_remade = eval(descriptor_repr)
+        assert ET.tostring(descriptor.to_xml()) == ET.tostring(
+            descriptor_remade.to_xml()
+        )
 
     def test_item_order(self) -> None:
         """Test item ordering."""


### PR DESCRIPTION
The `__repr__` methods return a string that can be `eval()`ed to recreate the object (this is checked with tests), showing how the object could be constructed.

I've also dropped the `didl_lite:res` property def from the base `DidlObject` because it was completely subsumed by the explicit `DidlObject.resources` property, so didn't make any sense in the repr output.