### PR TITLE
Annotate DidlObject properties that mypy doesn't see in __init__

### DIFF
--- a/didl_lite/didl_lite.py
+++ b/didl_lite/didl_lite.py
@@ -10,6 +10,7 @@ from typing import (
     Mapping,
     Optional,
     Sequence,
+    Tuple,
     Type,
     TypeVar,
     Union,
@@ -41,9 +42,9 @@ class DidlLiteException(Exception):
 class DidlObject:
     """DIDL Object."""
 
-    tag = None  # type: Optional[str]
-    upnp_class = "object"
-    didl_properties_defs = [
+    tag: Optional[str] = None
+    upnp_class: str = "object"
+    didl_properties_defs: List[Tuple[str, str, str]] = [
         ("didl_lite", "@id", "R"),
         ("didl_lite", "@parentID", "R"),
         ("didl_lite", "@restricted", "R"),
@@ -53,6 +54,12 @@ class DidlObject:
         ("didl_lite", "res", "O"),
         ("upnp", "writeStatus", "O"),
     ]
+
+    id: str
+    parent_id: str
+    res: List["Resource"]
+    xml_el: Optional[ET.Element]
+    descriptors: Sequence["Descriptor"]
 
     def __init__(
         self,


### PR DESCRIPTION
The base `DidlObject` has properties that are always there, but not explicitly set in the `__init__` method. Because they are set via `_set_properties`, mypy cannot infer them. Annotate them explicitly for better type checking in projects using this library.

This is just a small quality-of-life improvement, no need for a release just for this change.