### PR TITLE
Quirk to allow weirdly-cased upnp:class names

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -1,7 +1,10 @@
 Changes
 =======
 
-1.3.3 (unreleased)
+1.4.0 (unreleased)
+
+- Treat upnp:class as case-insensitive when in non-strict mode (@chishm)
+- Raise a `DidlLiteException` when upnp:class is invalid when in strict mode (@chishm)
 
 
 1.3.2 (2021-11-29)

--- a/didl_lite/didl_lite.py
+++ b/didl_lite/didl_lite.py
@@ -1097,6 +1097,8 @@ def from_xml_el(
             continue
         didl_object_type = type_by_upnp_class(upnp_class.text, strict)
         if didl_object_type is None:
+            if strict:
+                raise DidlLiteException(f"upnp:class {upnp_class.text} is unknown")
             continue
         didl_object = didl_object_type.from_xml(child_el, strict)
         didl_objects.append(didl_object)

--- a/didl_lite/didl_lite.py
+++ b/didl_lite/didl_lite.py
@@ -39,6 +39,11 @@ class DidlLiteException(Exception):
 
 
 # region: DidlObjects
+
+# upnp_class to python type mapping
+_upnp_class_map: Dict[str, Type["DidlObject"]] = {}
+
+
 class DidlObject:
     """DIDL Object."""
 
@@ -60,6 +65,13 @@ class DidlObject:
     res: List["Resource"]
     xml_el: Optional[ET.Element]
     descriptors: Sequence["Descriptor"]
+
+    @classmethod
+    def __init_subclass__(cls: Type["DidlObject"], **kwargs: Any) -> None:
+        """Create mapping of upnp_class to Python type for fast lookup."""
+        super().__init_subclass__(**kwargs)
+        assert cls.upnp_class not in _upnp_class_map
+        _upnp_class_map[cls.upnp_class] = cls
 
     def __init__(
         self,
@@ -1097,11 +1109,4 @@ def from_xml_el(
 # upnp_class to python type mapping
 def type_by_upnp_class(upnp_class: str) -> Optional[Type[DidlObject]]:
     """Get DidlObject-type by upnp_class."""
-    queue = DidlObject.__subclasses__()
-    while queue:
-        type_ = queue.pop()
-        queue.extend(type_.__subclasses__())
-
-        if type_.upnp_class == upnp_class:
-            return type_
-    return None
+    return _upnp_class_map.get(upnp_class)

--- a/didl_lite/didl_lite.py
+++ b/didl_lite/didl_lite.py
@@ -85,9 +85,6 @@ class DidlObject:
         self.xml_el = xml_el
         self.descriptors = descriptors if descriptors else []
 
-    def _clean_property_names(self, properties: Dict[str, Any]) -> Dict[str, Any]:
-        """Turn all property names into lower_camel_case."""
-
     def _ensure_required_properties(
         self, strict: bool, properties: Mapping[str, Any]
     ) -> None:

--- a/setup.py
+++ b/setup.py
@@ -44,6 +44,7 @@ setup(
     package_data={
         "didl_lite": ["py.typed"],
     },
+    python_requires=">=3.6",
     install_requires=INSTALL_REQUIRES,
     tests_require=TEST_REQUIRES,
 )

--- a/setup.py
+++ b/setup.py
@@ -23,7 +23,7 @@ TEST_REQUIRES = [
 
 setup(
     name="python-didl-lite",
-    version="1.3.3.dev0",
+    version="1.4.0.dev0",
     description=DESCRIPTION,
     long_description=LONG_DESCRIPTION,
     long_description_content_type="text/x-rst",

--- a/tests/test_didl_lite.py
+++ b/tests/test_didl_lite.py
@@ -1,6 +1,7 @@
 # -*- coding: utf-8 -*-
 """Unit tests for didl_lite."""
 
+import pytest
 from defusedxml import ElementTree as ET
 
 from didl_lite import didl_lite
@@ -70,8 +71,11 @@ class TestDidlLite:
         <upnp:longDescription>Long description</upnp:longDescription>
     </item>
 </DIDL-Lite>"""
-        items = didl_lite.from_xml_string(didl_string)
-        assert items == []  # Bad class should not be found, returning nothing
+        with pytest.raises(
+            didl_lite.DidlLiteException,
+            match="upnp:class Object.Item.AudioItem is unknown",
+        ):
+            didl_lite.from_xml_string(didl_string)
 
         items = didl_lite.from_xml_string(didl_string, strict=False)
         assert len(items) == 1

--- a/tests/test_didl_lite.py
+++ b/tests/test_didl_lite.py
@@ -55,6 +55,30 @@ class TestDidlLite:
         assert not hasattr(item, "non_existing")
         assert item.res == item.resources
 
+    def test_item_bad_class(self) -> None:
+        """Test item from XML that has a badly-cased upnp:class."""
+        didl_string = """
+<DIDL-Lite xmlns="urn:schemas-upnp-org:metadata-1-0/DIDL-Lite/"
+           xmlns:upnp="urn:schemas-upnp-org:metadata-1-0/upnp/"
+           xmlns:dc="http://purl.org/dc/elements/1.1/"
+           xmlns:sec="http://www.sec.co.kr/">
+    <item id="0" parentID="0" restricted="1">
+        <dc:title>Audio Item Title</dc:title>
+        <upnp:class>Object.Item.AudioItem</upnp:class>
+        <dc:language>English</dc:language>
+        <res protocolInfo="protocol_info">url</res>
+        <upnp:longDescription>Long description</upnp:longDescription>
+    </item>
+</DIDL-Lite>"""
+        items = didl_lite.from_xml_string(didl_string)
+        assert items == []  # Bad class should not be found, returning nothing
+
+        items = didl_lite.from_xml_string(didl_string, strict=False)
+        assert len(items) == 1
+
+        item = items[0]
+        assert isinstance(item, didl_lite.AudioItem)
+
     def test_item_from_xml_not_strict(self) -> None:
         """Test item from XML."""
         didl_string = """


### PR DESCRIPTION
This is a workaround for [an issue](https://github.com/home-assistant/core/issues/104556) raised with Home Assistant not being able to connect to the UPNP server on a Digitus NAS box.

There's a few other supporting changes here, split out into separate commits. They're each quite small and self-contained, but I'm happy to put in separate PRs for them if you'd prefer.