### PR TITLE
Cater for malformed XML from WiiM pro in non-strict mode.   Resolves #13

### DIFF
--- a/didl_lite/didl_lite.py
+++ b/didl_lite/didl_lite.py
@@ -1094,7 +1094,13 @@ def from_xml_el(
         # construct item
         upnp_class = child_el.find("./upnp:class", NAMESPACES)
         if upnp_class is None or not upnp_class.text:
-            continue
+            if strict:
+                continue
+            # WiiM Pro and possibly other Linkplay devices emit
+            # upnp_class above the item element instead of inside it
+            upnp_class = xml_el.find("./upnp:class", NAMESPACES)
+            if upnp_class is None or not upnp_class.text:
+                continue
         didl_object_type = type_by_upnp_class(upnp_class.text, strict)
         if didl_object_type is None:
             if strict:

--- a/tests/test_didl_lite.py
+++ b/tests/test_didl_lite.py
@@ -654,3 +654,29 @@ class TestDidlLite:
         assert hasattr(item, "otherItem")
         assert not hasattr(item, "other_item")
         assert item.otherItem == "otherItem"
+
+    def test_item_improper_class_nesting(self) -> None:
+        """
+        Test item from XML that has upnp_class element above item.
+
+        Cater for WiiM Pro and possibly other Linkplay devices that
+        emit upnp_class above the item element instead of inside it
+        """
+        didl_string = """
+<DIDL-Lite xmlns:dc="http://purl.org/dc/elements/1.1/"
+    xmlns:upnp="urn:schemas-upnp-org:metadata-1-0/upnp/"
+    xmlns="urn:schemas-upnp-org:metadata-1-0/DIDL-Lite/">
+    <upnp:class>object.item.audioItem.musicTrack</upnp:class>
+    <item id="0">
+        <res protocolInfo="protocol_info"></res>
+        <dc:title>Music Track Title</dc:title>
+        <dc:creator>Music Track Creator</dc:creator>
+        <upnp:artist>Artist</upnp:artist>
+        <upnp:album>Album</upnp:album>
+    </item>
+</DIDL-Lite>"""
+        items = didl_lite.from_xml_string(didl_string, strict=False)
+        assert len(items) == 1
+
+        item = items[0]
+        assert isinstance(item, didl_lite.MusicTrack)


### PR DESCRIPTION
As discussed in issue #13, this PR allows the library to identify the item class if the upnp_class element is above the item element instead of inside it.    This should improve compatibility with the WiiM Pro and possibly other WiiM/Linkplay devices.