### PR TITLE
Fix unbound prefix recovery when xmlns:dlna is absent

### DIFF
--- a/changes/52.bugfix.rst
+++ b/changes/52.bugfix.rst
@@ -1,0 +1,1 @@
+Fix unbound prefix recovery when ``xmlns:dlna`` is absent. Devices that emit unbound prefixes (e.g. ``<song:subTitle>``) without declaring ``xmlns:dlna`` are now handled correctly when ``strict=False``.

--- a/didl_lite/didl_lite.py
+++ b/didl_lite/didl_lite.py
@@ -1063,12 +1063,23 @@ def from_xml_string(xml_string: str, strict: bool = True) -> List[Union[DidlObje
         # Identify prefixes used but not defined.
         missing_prefixes = used_prefixes - defined_prefixes - {"DIDL-Lite", "dc", "upnp", "dlna"}
 
-        # Remove the "if missing_prefixes:" line and just keep the for loop
-        for prefix in missing_prefixes:
-            dlna_ns = 'xmlns:dlna="urn:schemas-dlna-org:metadata-1-0/"'
-            if dlna_ns in xml_string:
-                replacement = f'{dlna_ns} xmlns:{prefix}="http://tempuri.org/{prefix}/"'
-                xml_string = xml_string.replace(dlna_ns, replacement)
+        if missing_prefixes:
+            # Inject temporary namespace declarations into the DIDL-Lite root
+            # opening tag. Anchoring on `<DIDL-Lite` (always present in valid
+            # DIDL-Lite documents) instead of an optional `xmlns:dlna` allows
+            # us to recover XML from devices that omit the dlna namespace
+            # declaration entirely (observed on JBL Authentics and
+            # WiiM/LinkPlay players sending `<song:*>` without `xmlns:dlna`).
+            injections = " ".join(
+                f'xmlns:{prefix}="http://tempuri.org/{prefix}/"'
+                for prefix in sorted(missing_prefixes)
+            )
+            xml_string = re.sub(
+                r"<DIDL-Lite\b",
+                f"<DIDL-Lite {injections}",
+                xml_string,
+                count=1,
+            )
 
     # Proceed with parsing using the (potentially) patched xml_string
     xml_el = defusedxml.ElementTree.fromstring(xml_string)

--- a/didl_lite/didl_lite.py
+++ b/didl_lite/didl_lite.py
@@ -1071,8 +1071,7 @@ def from_xml_string(xml_string: str, strict: bool = True) -> List[Union[DidlObje
             # declaration entirely (observed on JBL Authentics and
             # WiiM/LinkPlay players sending `<song:*>` without `xmlns:dlna`).
             injections = " ".join(
-                f'xmlns:{prefix}="http://tempuri.org/{prefix}/"'
-                for prefix in sorted(missing_prefixes)
+                f'xmlns:{prefix}="http://tempuri.org/{prefix}/"' for prefix in sorted(missing_prefixes)
             )
             xml_string = re.sub(
                 r"<DIDL-Lite\b",

--- a/tests/test_didl_lite.py
+++ b/tests/test_didl_lite.py
@@ -696,6 +696,35 @@ class TestDidlLite:
         assert objs[0].sub_title == "Test Subtitle"
         assert isinstance(objs[0], didl_lite.MusicTrack)
 
+    def test_from_xml_string_unbound_prefix_without_dlna_namespace(self) -> None:
+        """Test unbound prefix recovery when xmlns:dlna is absent.
+
+        Regression: the previous implementation anchored the namespace
+        injection on an existing `xmlns:dlna` declaration. Devices such as
+        JBL Authentics and WiiM/LinkPlay players emit `<song:*>` tags
+        without declaring `xmlns:dlna`, leaving the unbound prefix in place
+        and breaking parsing even with strict=False.
+        """
+        broken_xml = (
+            '<DIDL-Lite xmlns="urn:schemas-upnp-org:metadata-1-0/DIDL-Lite/" '
+            'xmlns:dc="http://purl.org/dc/elements/1.1/" '
+            'xmlns:upnp="urn:schemas-upnp-org:metadata-1-0/upnp/">'
+            '<item id="1" parentID="0" restricted="1">'
+            "<dc:title>Test Title</dc:title>"
+            "<song:subTitle>Test Subtitle</song:subTitle>"
+            "<upnp:class>object.item.audioItem.musicTrack</upnp:class>"
+            "</item>"
+            "</DIDL-Lite>"
+        )
+
+        objs = didl_lite.from_xml_string(broken_xml, strict=False)
+
+        assert len(objs) == 1
+        assert objs[0].title == "Test Title"
+        assert "sub_title" in objs[0].__dict__
+        assert objs[0].sub_title == "Test Subtitle"
+        assert isinstance(objs[0], didl_lite.MusicTrack)
+
     def test_music_track_artist_and_genre(self) -> None:
         """Test MusicTrack artist and genre properties."""
         track = didl_lite.MusicTrack(


### PR DESCRIPTION
## Summary

The `strict=False` recovery added in #35 anchored its namespace injection on an existing `xmlns:dlna` declaration. Some real-world devices (JBL Authentics, WiiM/LinkPlay) emit `<song:*>` tags **without** declaring `xmlns:dlna`, so the injection was silently skipped and the unbound prefix remained, raising `ParseError` when the path was otherwise supposed to recover.

This regression is observable today: `python-didl-lite==1.5.0` is shipped via `async-upnp-client` into Music Assistant, where JBL Authentics 200 owners still see ~100 `unbound prefix` errors per hour and a broken DLNA state-sync loop (downstream tracking: [music-assistant/support#4398](https://github.com/music-assistant/support/issues/4398)).

## Fix

Anchor the namespace injection on the DIDL-Lite root opening tag (\`<DIDL-Lite\`) instead of the optional \`xmlns:dlna\` declaration. The root element is guaranteed to be present in any valid DIDL-Lite document, so recovery works regardless of which namespace declarations the producer chose to include.

Also batches all missing prefix injections into a single regex substitution rather than looping per-prefix.

## Test

Added \`test_from_xml_string_unbound_prefix_without_dlna_namespace\` that exercises the no-\`xmlns:dlna\` case. The existing \`test_from_xml_string_unbound_prefix\` (with \`xmlns:dlna\` present) still passes — the new injection is anchored on the root tag which is also present in that case.

\`\`\`
$ python3 -m pytest tests/ -v
...
26 passed in 0.18s
\`\`\`

\`ruff check\` clean.

## Compatibility

- No behavior change when \`strict=True\` (recovery code path is gated by \`if not strict\`).
- No behavior change for XML that did contain \`xmlns:dlna\` and had unbound prefixes (#35 case continues to work).
- Recovers an additional class of input that previously raised.